### PR TITLE
fix forever loop when O E-xxx happens

### DIFF
--- a/metric/flat_span_f1.py
+++ b/metric/flat_span_f1.py
@@ -128,6 +128,13 @@ def bmes_decode(char_label_list: List[Tuple[str, str]]) -> Tuple[str, List[Tag]]
         if idx + 1 == length and current_label == "B":
             current_label = "S"
 
+        if idx == 0:
+            previous_label = ''
+        else:
+            previous_label = char_label_list[idx-1][1][0]
+        if previous_label in ['O', 'S', 'E'] and current_label == 'E':
+            current_label = 'S'
+
         # merge chars
         if current_label == "O":
             idx += 1


### PR DESCRIPTION
当pred labels 出现类似 ['O', 'E-xxx',....]情况时，bmes_decode 会出现死循环